### PR TITLE
Routing by port

### DIFF
--- a/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/instance/Endpoint.java
+++ b/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/instance/Endpoint.java
@@ -437,6 +437,16 @@ public interface Endpoint extends Matcher<TagCondition>, Attributes {
     }
 
     /**
+     * Checks if the specified port matches the current port.
+     *
+     * @param port The port to check against the current port.
+     * @return {@code true} if the specified port matches the current port, {@code false} otherwise.
+     */
+    default boolean isPort(int port) {
+        return getPort() == port;
+    }
+
+    /**
      * Evaluates the predicate associated with this endpoint, if any, to determine
      * if this endpoint satisfies the conditions defined by the predicate.
      * <p>

--- a/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/invoke/filter/RouteFilter.java
+++ b/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/invoke/filter/RouteFilter.java
@@ -45,7 +45,9 @@ public interface RouteFilter {
 
     int ORDER_LOCALHOST = ORDER_STICKY + 100;
 
-    int ORDER_HEALTH = ORDER_LOCALHOST + 100;
+    int ORDER_PORT = ORDER_LOCALHOST + 100;
+
+    int ORDER_HEALTH = ORDER_PORT + 100;
 
     int ORDER_VIRTUAL = ORDER_HEALTH + 100;
 

--- a/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/invoke/filter/route/PortFilter.java
+++ b/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/invoke/filter/route/PortFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © ${year} ${owner} (${email})
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jd.live.agent.governance.invoke.filter.route;
+
+import com.jd.live.agent.core.extension.annotation.Extension;
+import com.jd.live.agent.governance.annotation.ConditionalOnFlowControlEnabled;
+import com.jd.live.agent.governance.invoke.OutboundInvocation;
+import com.jd.live.agent.governance.invoke.filter.RouteFilter;
+import com.jd.live.agent.governance.invoke.filter.RouteFilterChain;
+import com.jd.live.agent.governance.request.Portable;
+import com.jd.live.agent.governance.request.ServiceRequest.OutboundRequest;
+
+/**
+ * A class that implements the {@link RouteFilter} interface.
+ * It filters outbound requests based on the port number.
+ *
+ * @since 1.6.0
+ */
+@Extension(value = "PortFilter", order = RouteFilter.ORDER_PORT)
+@ConditionalOnFlowControlEnabled
+public class PortFilter implements RouteFilter {
+
+    @Override
+    public <T extends OutboundRequest> void filter(OutboundInvocation<T> invocation, RouteFilterChain chain) {
+        T request = invocation.getRequest();
+        if (request instanceof Portable) {
+            Integer port = ((Portable) request).getPort();
+            if (port != null) {
+                invocation.getRouteTarget().filter(e -> e.isPort(port));
+            }
+        }
+        chain.filter(invocation);
+    }
+}

--- a/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/request/HttpRequest.java
+++ b/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/request/HttpRequest.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * inbound and outbound requests.
  * </p>
  */
-public interface HttpRequest extends ServiceRequest {
+public interface HttpRequest extends ServiceRequest, Portable {
 
     /**
      * Returns the URI of the request.
@@ -44,13 +44,6 @@ public interface HttpRequest extends ServiceRequest {
      * @return The schema as a string.
      */
     String getSchema();
-
-    /**
-     * Returns the port number of the request.
-     *
-     * @return The port number.
-     */
-    Integer getPort();
 
     /**
      * Returns the host name of the request.

--- a/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/request/Portable.java
+++ b/joylive-core/joylive-governance-api/src/main/java/com/jd/live/agent/governance/request/Portable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © ${year} ${owner} (${email})
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jd.live.agent.governance.request;
+
+/**
+ * An interface representing an object that has a port.
+ * Implementing classes should provide a method to get the port number.
+ */
+public interface Portable {
+
+    /**
+     * Returns the port number of the request.
+     *
+     * @return The port number.
+     */
+    Integer getPort();
+}
+

--- a/joylive-core/joylive-governance-api/src/main/resources/META-INF/services/com.jd.live.agent.governance.invoke.filter.RouteFilter
+++ b/joylive-core/joylive-governance-api/src/main/resources/META-INF/services/com.jd.live.agent.governance.invoke.filter.RouteFilter
@@ -11,3 +11,4 @@ com.jd.live.agent.governance.invoke.filter.route.StickyFilter
 com.jd.live.agent.governance.invoke.filter.route.VirtualFilter
 com.jd.live.agent.governance.invoke.filter.route.CircuitBreakerFilter
 com.jd.live.agent.governance.invoke.filter.route.GroupFilter
+com.jd.live.agent.governance.invoke.filter.route.PortFilter


### PR DESCRIPTION
## What is the purpose of the change?

Such a service call, “http://service-provider:8080/echo/”, requires routing according to the 8080 port.

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/jd-opensource/joylive-agent/issues) field for the change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. If the new feature or significant change is committed, please remember to add sample in [joylive-demo](https://github.com/jd-opensource/joylive-agent/tree/main/joylive-demo) project.
- [x] Make sure gitHub actions can pass. [Why the workflow is failing and how to fix it?](../CONTRIBUTING.md)